### PR TITLE
upload versioned distributions to s3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ pal
 gopal
 cache/
 vendor/
+.build/
 .vscode/
 *.pal
 *.csv

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,14 @@ branches:
   - master
 
 after_success:
-- make -j2 .build/${TRAVIS_REPO_SLUG##*/}.linux.amd64
-- cp .build/${TRAVIS_REPO_SLUG##*/}.linux.amd64 .build/${TRAVIS_REPO_SLUG##*/}.x86_64
+- make artifacts
 
 addons:
   artifacts:
     working_dir: ".build"
     paths:
-      - "${TRAVIS_REPO_SLUG##*/}.x86_64"
-      - "${TRAVIS_REPO_SLUG##*/}.linux.amd64"
+    - $(git ls-files -o | grep .tar.gz | tr "\n" ":")
     debug: true
     s3_region: eu-west-1
     s3_bucket: remerge-artifacts
-    target_paths: $TRAVIS_REPO_SLUG/$TRAVIS_BRANCH
+    target_paths: "$TRAVIS_REPO_SLUG"

--- a/Makefile
+++ b/Makefile
@@ -2,3 +2,14 @@ PROJECT := gopal
 PACKAGE := github.com/remerge/$(PROJECT)
 
 include mkf/Makefile.common mkf/Makefile.app
+
+ARTIFACTS_VERSION = $(shell git rev-parse --short HEAD)
+
+.build/$(PROJECT)-$(ARTIFACTS_VERSION)-%_amd64.tar.gz: .build/$(PROJECT).%.amd64
+	tar --show-transform --transform 's,$<,$(PROJECT),' -czvf $@ $<
+	echo $@ $$(openssl sha256 < $@)
+	tar -tvf $@
+
+artifacts: \
+	.build/$(PROJECT)-$(ARTIFACTS_VERSION)-linux_amd64.tar.gz \
+	.build/$(PROJECT)-$(ARTIFACTS_VERSION)-darwin_amd64.tar.gz

--- a/builder.go
+++ b/builder.go
@@ -97,4 +97,3 @@ func (b *Builder) BuildTo(w io.Writer) (err error) {
 
 	return
 }
-

--- a/header.go
+++ b/header.go
@@ -31,4 +31,3 @@ func (h *PalHeader) Validate() (err error) {
 	}
 	return
 }
-

--- a/offsets.go
+++ b/offsets.go
@@ -48,4 +48,3 @@ func (o *v1offsets) WriteTo(w io.Writer) (n int64, err error) {
 	err = o.CHD.Write(w)
 	return
 }
-


### PR DESCRIPTION
Versioning the compiled binaries makes it a lot faster to deploy, as the call to S3 is only necessary when the requested version is not installed.

I'll hold off on this until I see how this fits in with the new makefiles.